### PR TITLE
WebSocket API

### DIFF
--- a/src/main/kotlin/spark/kotlin/Http.kt
+++ b/src/main/kotlin/spark/kotlin/Http.kt
@@ -242,7 +242,24 @@ fun internalServerError(function: RouteHandler.() -> Any) {
     }
 }
 
-//----------------- TODO: Web sockets -----------------//
+//----------------- Web sockets -----------------//
+
+/**
+ * Registers a WebSocket handler class under a given URL.
+ * @param url The URL to attach the WebSocket handler to.
+ * @param handler A class annotated with Jetty's WebSocket annotations.
+ */
+fun webSocket(url: String, handler: Class<*>) {
+    Spark.webSocket(url, handler)
+}
+
+/**
+ * Sets the idle timeout for WebSocket connections.
+ * @param timeout The amount of time, in milliseconds, that a connection can remain established for with no activity.
+ */
+fun webSocketIdleTimeoutMillis(timeout: Int) {
+    Spark.webSocketIdleTimeoutMillis(timeout)
+}
 
 //----------------- exception mapping -----------------//
 
@@ -472,6 +489,16 @@ class Http(val service: Service) {
     val staticFiles: Service.StaticFiles = service.staticFiles
     //----------------- Redirect -----------------//
     val redirect: Redirect = service.redirect
+
+    //----------------- WebSockets ------------------//
+    // These behave in exactly the same way as the static WebSocket methods.
+    fun webSocket(path: String, handler: Class<*>) {
+        service.webSocket(path, handler)
+    }
+
+    fun webSocketIdleTimeoutMillis(timeout: Int) {
+        service.webSocketIdleTimeoutMillis(timeout)
+    }
 
     /**
      * Gets the port

--- a/src/main/kotlin/spark/kotlin/Http.kt
+++ b/src/main/kotlin/spark/kotlin/Http.kt
@@ -249,8 +249,8 @@ fun internalServerError(function: RouteHandler.() -> Any) {
  * @param url The URL to attach the WebSocket handler to.
  * @param handler A class annotated with Jetty's WebSocket annotations.
  */
-fun webSocket(url: String, handler: Class<*>) {
-    Spark.webSocket(url, handler)
+fun webSocket(url: String, handler: KClass<*>) {
+    Spark.webSocket(url, handler.java)
 }
 
 /**
@@ -492,8 +492,8 @@ class Http(val service: Service) {
 
     //----------------- WebSockets ------------------//
     // These behave in exactly the same way as the static WebSocket methods.
-    fun webSocket(path: String, handler: Class<*>) {
-        service.webSocket(path, handler)
+    fun webSocket(path: String, handler: KClass<*>) {
+        service.webSocket(path, handler.java)
     }
 
     fun webSocketIdleTimeoutMillis(timeout: Int) {

--- a/src/test/kotlin/spark/examples/instance/InstanceApiExample.kt
+++ b/src/test/kotlin/spark/examples/instance/InstanceApiExample.kt
@@ -15,7 +15,7 @@
  */
 package spark.examples.instance
 
-import org.omg.CosNaming.NamingContextPackage.NotFound
+import spark.examples.testutil.SampleWebSocketHandler
 import spark.kotlin.Http
 import spark.kotlin.halt
 import spark.kotlin.ignite
@@ -27,6 +27,8 @@ import spark.kotlin.ignite
 fun main(args: Array<String>) {
 
     val http: Http = ignite()
+
+    http.webSocket("/ws", SampleWebSocketHandler::class.java)
 
     http.staticFiles.location("/public")
 
@@ -74,5 +76,6 @@ fun main(args: Array<String>) {
         response.body(exception.message)
     }
 }
+
 
 class NotFoundException(message: String) : Exception(message)

--- a/src/test/kotlin/spark/examples/instance/InstanceApiExample.kt
+++ b/src/test/kotlin/spark/examples/instance/InstanceApiExample.kt
@@ -28,7 +28,7 @@ fun main(args: Array<String>) {
 
     val http: Http = ignite()
 
-    http.webSocket("/ws", SampleWebSocketHandler::class.java)
+    http.webSocket("/ws", SampleWebSocketHandler::class)
 
     http.staticFiles.location("/public")
 

--- a/src/test/kotlin/spark/examples/static/StaticApiExample.kt
+++ b/src/test/kotlin/spark/examples/static/StaticApiExample.kt
@@ -22,7 +22,7 @@ import spark.kotlin.*
  * Example usage of spark-kotlin via STATIC API.
  */
 fun main(args: Array<String>) {
-    webSocket("/ws", SampleWebSocketHandler::class.java)
+    webSocket("/ws", SampleWebSocketHandler::class)
 
     staticFiles.location("/public")
 

--- a/src/test/kotlin/spark/examples/static/StaticApiExample.kt
+++ b/src/test/kotlin/spark/examples/static/StaticApiExample.kt
@@ -15,12 +15,14 @@
  */
 package spark.examples.static
 
+import spark.examples.testutil.SampleWebSocketHandler
 import spark.kotlin.*
 
 /**
  * Example usage of spark-kotlin via STATIC API.
  */
 fun main(args: Array<String>) {
+    webSocket("/ws", SampleWebSocketHandler::class.java)
 
     staticFiles.location("/public")
 

--- a/src/test/kotlin/spark/examples/testutil/SampleWebSocketHandler.kt
+++ b/src/test/kotlin/spark/examples/testutil/SampleWebSocketHandler.kt
@@ -1,0 +1,36 @@
+package spark.examples.testutil
+
+import org.eclipse.jetty.websocket.api.Session
+import org.eclipse.jetty.websocket.api.annotations.*
+import java.io.InputStream
+
+@WebSocket class SampleWebSocketHandler {
+    @OnWebSocketConnect
+    fun onConnect(s: Session) {
+        println("${s.remoteAddress} has opened a WebSocket connection.")
+    }
+
+    @OnWebSocketError
+    fun onError(s: Session, t: Throwable) {
+        println("An error was encountered on ${s.remoteAddress}' connection: $t")
+    }
+
+    // Handles text messages by echoing them back to the sender
+    @OnWebSocketMessage
+    fun onMessage(s: Session, msg: String) {
+        println("Message received from ${s.remoteAddress}: $msg")
+        s.remote.sendString(msg)
+    }
+
+    // Handles binary messages
+    @OnWebSocketMessage
+    fun onMessage(s: Session, input: InputStream) {
+        println("Binary message received from ${s.remoteAddress}")
+    }
+
+    @OnWebSocketClose
+    fun onClose(s: Session, code: Int, reason: String) {
+        println("${s.remoteAddress} has closed their connection: $code ($reason)")
+    }
+
+}


### PR DESCRIPTION
This PR adds support for mounting WebSocket handler classes on URLs.

The [API call](https://github.com/perwendel/spark-kotlin/compare/master...0x41111111:websocket-support?expand=1#diff-28a4352abc3e0ffa189aeb217e1d3070R252) essentially mirrors its Java counterpart. It takes a URL and a class containing WebSocket handler methods.

In addition, `webSocketIdleTimeoutMillis` has also been implemented, which, like `webSocket`, works exactly like the Java version.

The examples under src/test/ have been updated and a sample handler class has been added.

Usage:

```kotlin
// Attach a WebSocket handler to a Spark instance
val http = ignite()
http.webSocket("/ws", MyTotallyImplementedWebSocketHandler::class)
// Make connections time out after 30 seconds with no activity
http.webSocketIdleTimeoutMillis(30000)

// Attach a WebSocket handler to a static Spark environment
webSocket("/ws", MyTotallyImplementedWebSocketHandler::class)
// Set the inactivity timeout to 30 seconds
webSocketIdleTimeoutMillis(30000)
```

Related to #11.