### PR TITLE
Issue #13 - HTTP#secure allow null values for trustStore params

### DIFF
--- a/src/main/kotlin/spark/kotlin/Http.kt
+++ b/src/main/kotlin/spark/kotlin/Http.kt
@@ -16,6 +16,7 @@
 package spark.kotlin
 
 import spark.*
+
 import kotlin.reflect.KClass
 
 // STATIC API BEGIN
@@ -52,6 +53,13 @@ fun secure(keyStoreFile: String, keyStorePassword: String, truststoreFile: Strin
  */
 fun secure(keyStoreFile: String, keyStorePassword: String, truststoreFile: String, truststorePassword: String, needsClientCert: Boolean) {
     Spark.secure(keyStoreFile, keyStorePassword, truststoreFile, truststorePassword, needsClientCert)
+}
+
+/**
+ * Set the connection to be secure (HTTPS)
+ */
+fun secure() {
+    Spark.secure(null, null, null, null)
 }
 
 /**
@@ -503,6 +511,14 @@ class Http(val service: Service) {
         service.secure(keyStoreFile, keyStorePassword, truststoreFile, truststorePassword, needsClientCert)
         return this
     }
+
+    /**
+     * Set the connection to be secure (HTTPS)
+     */
+     fun secure(): Http {
+        Spark.secure(null, null, null, null)
+        return this
+      }
 
     /**
      * Sets the ip address

--- a/src/test/kotlin/spark/examples/static/StaticApiSecureWithoutArgsExample.kt
+++ b/src/test/kotlin/spark/examples/static/StaticApiSecureWithoutArgsExample.kt
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017 Per Wendel, Love Löfdahl
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package spark.examples.static
+
+import spark.kotlin.get
+import spark.kotlin.notFound
+import spark.kotlin.port
+import spark.kotlin.secure
+
+/**
+ * Example usage of spark-kotlin via STATIC API.
+ */
+fun main(args: Array<String>) {
+
+    port(4321)
+    secure()
+
+    // when accessing don't forget https
+    get("/hello") {
+        "Hello Secure Static Spark Kotlin"
+    }
+
+    notFound {
+        "there's nothing here"
+    }
+
+}


### PR DESCRIPTION
* Overloads HTTP#secure function that takes no args -- allowing null trustStore params